### PR TITLE
Add planning docs for reports, SoD and operations

### DIFF
--- a/document/API_TASKS.md
+++ b/document/API_TASKS.md
@@ -21,3 +21,11 @@
 - [ ] Middleware phân quyền
 - [ ] Tài liệu API (Swagger)
 - [ ] Unit test cho endpoint
+- [ ] API báo cáo nhập–xuất–tồn theo thời gian/kho/SKU
+- [ ] API báo cáo thiếu hụt theo BOM
+- [ ] API báo cáo tuổi tồn
+- [ ] API truy vết lô/serial
+- [ ] Kiểm tra SoD trong quy trình duyệt GRN, Issue, PR, PO
+- [ ] Xác nhận hai bước khi quét mã với cảnh báo màu
+- [ ] Cơ chế đối soát kiểm kê định kỳ kèm lưu ảnh chứng từ
+- [ ] Khóa giao dịch tạm thời và xử lý hàng đợi khi tồn âm

--- a/document/DATABASE_DESIGN_TASKS.md
+++ b/document/DATABASE_DESIGN_TASKS.md
@@ -18,5 +18,9 @@
 - [ ] Thiết kế bảng `kiem_ke_dieu_chinh`
 - [ ] Thiết kế bảng `phieu_yeu_cau_mua` (PR)
 - [ ] Thiết kế bảng `don_mua_hang` (PO)
+- [ ] Thiết kế view/query cho báo cáo nhập–xuất–tồn
+- [ ] Thiết kế view/query thiếu hụt theo BOM
+- [ ] Thiết kế view/query báo cáo tuổi tồn
+- [ ] Thiết kế view truy vết lô/serial
 - [ ] Rà soát quan hệ và khóa ngoại
 - [ ] Sinh script migration ban đầu

--- a/document/ROLE_PERMISSION_TASKS.md
+++ b/document/ROLE_PERMISSION_TASKS.md
@@ -7,6 +7,8 @@
 - [ ] Mapping quyền cho role Thu mua
 - [ ] Mapping quyền cho role Duyệt
 - [ ] Mapping quyền cho role CEO
+- [ ] Thiết lập quy tắc SoD: người tạo phiếu ≠ người duyệt cuối
+- [ ] Kiểm tra SoD cho các quy trình GRN, Issue, PR, PO
 - [ ] Viết script seed role & quyền
 - [ ] Áp dụng kiểm tra phân quyền trong API
 - [ ] Kiểm thử truy cập cho từng role

--- a/document/SCREEN_TASKS.md
+++ b/document/SCREEN_TASKS.md
@@ -24,5 +24,8 @@
 - [ ] Thiết kế màn hình yêu cầu lãnh vật tư
 - [ ] Thiết kế màn hình phiếu yêu cầu mua (PR)
 - [ ] Thiết kế màn hình đơn mua hàng (PO)
-- [ ] Thiết kế màn hình báo cáo tồn kho
+- [ ] Thiết kế màn hình báo cáo nhập–xuất–tồn theo thời gian/kho/SKU
+- [ ] Thiết kế đồ thị thiếu hụt theo BOM
+- [ ] Thiết kế màn hình báo cáo tuổi tồn
+- [ ] Thiết kế màn hình truy vết lô/serial
 - [ ] Áp dụng phân quyền hiển thị UI

--- a/document/non-functional/NON_FUNCTIONAL_TASKS.md
+++ b/document/non-functional/NON_FUNCTIONAL_TASKS.md
@@ -1,0 +1,7 @@
+# Non-functional Requirements Tasks
+
+- [ ] Thiết lập benchmark <1s cho thao tác quét và xử lý nền cho báo cáo lớn
+- [ ] Cấu hình backup DB hằng ngày với RTO <4h và RPO <24h
+- [ ] Thu thập và lưu log thay đổi, lưu trữ ảnh chứng từ ≥12 tháng
+- [ ] Định nghĩa metrics và alert giám sát cho từng chỉ tiêu
+- [ ] Chuẩn bị checklist kiểm thử hiệu năng và khôi phục dữ liệu

--- a/document/operations/OPERATIONS_TASKS.md
+++ b/document/operations/OPERATIONS_TASKS.md
@@ -1,0 +1,8 @@
+# Operations & Configuration Tasks
+
+- [ ] Thiết kế giao diện cấu hình Min/Max theo SKU-kho
+- [ ] Xác định quy tắc đánh số chứng từ và quản lý mẫu in
+- [ ] Xây dựng quy trình import danh mục ban đầu từ CSV
+- [ ] Xác định module xử lý cấu hình và cách lưu vào CSDL
+- [ ] Viết hướng dẫn sử dụng và triển khai cho đội vận hành
+- [ ] Mô tả quy trình xử lý sự cố: quét nhầm, chênh lệch kiểm kê, tồn âm do đồng bộ chậm

--- a/document/reporting/REPORT_OUTPUT_SPEC.md
+++ b/document/reporting/REPORT_OUTPUT_SPEC.md
@@ -1,0 +1,7 @@
+# Report Output & Validation
+
+- [ ] Định nghĩa định dạng dữ liệu cho báo cáo nhập–xuất–tồn theo thời gian/kho/SKU
+- [ ] Định nghĩa định dạng dữ liệu cho báo cáo thiếu hụt theo BOM
+- [ ] Định nghĩa định dạng dữ liệu cho báo cáo tuổi tồn
+- [ ] Định nghĩa định dạng dữ liệu cho truy vết lô/serial
+- [ ] Tiêu chí kiểm thử và mẫu dữ liệu cho từng báo cáo

--- a/document/testing/TESTING_TASKS.md
+++ b/document/testing/TESTING_TASKS.md
@@ -1,0 +1,7 @@
+# UAT & System Testing Tasks
+
+- [ ] Checklist UAT cho nhập, xuất, lãnh, mua, kiểm kê
+- [ ] Dữ liệu mẫu và tiêu chí Pass/Fail cho từng quy trình
+- [ ] Kịch bản lỗi thường gặp và cách xử lý
+- [ ] Xác định môi trường kiểm thử và cách reset dữ liệu
+- [ ] Gắn trách nhiệm (RACI) cho từng vai trò trong UAT


### PR DESCRIPTION
## Summary
- expand API and screen tasks to cover reporting, SoD checks, and risk mitigations
- document database views and permissions for report and SoD requirements
- add non-functional, operations, testing, and reporting task lists in separate folders

## Testing
- `npx -y markdownlint-cli@0.39.0 "document/**/*.md" README.md` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6897dfda314883328b0e877eda513533