### PR TITLE
Add static HTML mockups for inventory workflows

### DIFF
--- a/code/mockup/bins.html
+++ b/code/mockup/bins.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>Quản lý bin</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h2>Quản lý bin</h2>
+<table>
+  <tr><th>Khu</th><th>Bin</th><th>Kho</th></tr>
+  <tr><td>A</td><td>A1</td><td>WH1</td></tr>
+  <tr><td>A</td><td>A2</td><td>WH1</td></tr>
+  <tr><td>B</td><td>B1</td><td>WH2</td></tr>
+</table>
+</body>
+</html>

--- a/code/mockup/bom_detail.html
+++ b/code/mockup/bom_detail.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>Chi tiết BOM</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h2>Chi tiết BOM: BOM001</h2>
+<table>
+  <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th></tr>
+  <tr><td>VT001</td><td>Bulong M8</td><td>4</td><td>Cái</td></tr>
+  <tr><td>VT003</td><td>Thân máy</td><td>1</td><td>Bộ</td></tr>
+</table>
+</body>
+</html>

--- a/code/mockup/bom_list.html
+++ b/code/mockup/bom_list.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>Danh sách BOM</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h2>Danh sách BOM</h2>
+<table>
+  <tr><th>Mã BOM</th><th>Tên BOM</th><th>Phiên bản</th></tr>
+  <tr><td>BOM001</td><td>Máy A</td><td>v1</td></tr>
+  <tr><td>BOM002</td><td>Máy B</td><td>v2</td></tr>
+</table>
+</body>
+</html>

--- a/code/mockup/dashboard.html
+++ b/code/mockup/dashboard.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>Dashboard</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h2>Dashboard</h2>
+<div>Tổng số phiếu nhập chờ duyệt: <strong>3</strong></div>
+<div>Tổng số phiếu xuất chờ duyệt: <strong>2</strong></div>
+<div>Tồn kho thấp hơn min: <strong>5 SKU</strong></div>
+</body>
+</html>

--- a/code/mockup/grn_form.html
+++ b/code/mockup/grn_form.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>Phiếu nhập (GRN)</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h2>Phiếu nhập (GRN)</h2>
+<form>
+  <div><label>Nhà cung cấp</label><input type="text" value="NCC ABC"></div>
+  <div><label>Ngày nhập</label><input type="date" value="2025-05-01"></div>
+  <div>
+    <table>
+      <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th></tr>
+      <tr><td>VT001</td><td>Bulong M8</td><td><input type="number" value="100"></td><td>Cái</td></tr>
+      <tr><td>VT002</td><td>Đai ốc M8</td><td><input type="number" value="100"></td><td>Cái</td></tr>
+    </table>
+  </div>
+  <button type="submit">Gửi phê duyệt</button>
+</form>
+</body>
+</html>

--- a/code/mockup/index.html
+++ b/code/mockup/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>DEMAX Mockups</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header>
+  <h1>DEMAX Inventory Mockups</h1>
+</header>
+<nav>
+  <a href="login.html">Đăng nhập</a>
+  <a href="dashboard.html">Dashboard</a>
+  <a href="warehouses.html">Danh sách kho</a>
+  <a href="bins.html">Quản lý bin</a>
+  <a href="grn_form.html">Phiếu nhập (GRN)</a>
+  <a href="issue_form.html">Phiếu xuất (Issue)</a>
+  <a href="bom_list.html">Danh sách BOM</a>
+  <a href="bom_detail.html">Chi tiết BOM</a>
+  <a href="request_issue_bom.html">Lãnh theo BOM</a>
+  <a href="request_issue_general.html">Lãnh kho chung</a>
+  <a href="pr_form.html">Phiếu yêu cầu mua (PR)</a>
+  <a href="po_form.html">Đơn mua hàng (PO)</a>
+  <a href="report_inventory.html">Báo cáo tồn kho</a>
+</nav>
+</body>
+</html>

--- a/code/mockup/issue_form.html
+++ b/code/mockup/issue_form.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>Phiếu xuất (Issue)</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h2>Phiếu xuất (Issue)</h2>
+<form>
+  <div><label>Kho xuất</label><input type="text" value="WH1"></div>
+  <div><label>Ngày xuất</label><input type="date" value="2025-05-02"></div>
+  <div>
+    <table>
+      <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th></tr>
+      <tr><td>VT001</td><td>Bulong M8</td><td><input type="number" value="50"></td><td>Cái</td></tr>
+    </table>
+  </div>
+  <button type="submit">Gửi phê duyệt</button>
+</form>
+</body>
+</html>

--- a/code/mockup/login.html
+++ b/code/mockup/login.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>Đăng nhập</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h2>Đăng nhập</h2>
+<form>
+  <div>
+    <label>Tên đăng nhập</label>
+    <input type="text" value="receiver1">
+  </div>
+  <div>
+    <label>Mật khẩu</label>
+    <input type="password" value="password">
+  </div>
+  <button type="submit">Login</button>
+</form>
+</body>
+</html>

--- a/code/mockup/po_form.html
+++ b/code/mockup/po_form.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>Đơn mua hàng (PO)</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h2>Đơn mua hàng (PO)</h2>
+<form>
+  <div><label>Nhà cung cấp</label><input type="text" value="NCC XYZ"></div>
+  <div>
+    <table>
+      <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th><th>Đơn giá</th></tr>
+      <tr>
+        <td>VT007</td>
+        <td>Motor</td>
+        <td><input type="number" value="2"></td>
+        <td>Cái</td>
+        <td><input type="number" value="5000000"></td>
+      </tr>
+    </table>
+  </div>
+  <button type="submit">Trình ký</button>
+</form>
+</body>
+</html>

--- a/code/mockup/pr_form.html
+++ b/code/mockup/pr_form.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>Phiếu yêu cầu mua (PR)</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h2>Phiếu yêu cầu mua (PR)</h2>
+<form>
+  <div><label>Người yêu cầu</label><input type="text" value="NV001"></div>
+  <div>
+    <table>
+      <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th></tr>
+      <tr><td>VT007</td><td>Motor</td><td><input type="number" value="2"></td><td>Cái</td></tr>
+    </table>
+  </div>
+  <button type="submit">Gửi phê duyệt</button>
+</form>
+</body>
+</html>

--- a/code/mockup/report_inventory.html
+++ b/code/mockup/report_inventory.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>Báo cáo tồn kho</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h2>Báo cáo tồn kho</h2>
+<table>
+  <tr><th>SKU</th><th>Tên vật tư</th><th>Kho</th><th>Tồn</th><th>Min</th><th>Max</th></tr>
+  <tr><td>VT001</td><td>Bulong M8</td><td>WH1</td><td>80</td><td>50</td><td>200</td></tr>
+  <tr><td>VT005</td><td>Keo dán</td><td>WH1</td><td>1</td><td>5</td><td>20</td></tr>
+</table>
+</body>
+</html>

--- a/code/mockup/request_issue_bom.html
+++ b/code/mockup/request_issue_bom.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>Lãnh vật tư theo BOM</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h2>Lãnh vật tư theo BOM</h2>
+<form>
+  <div><label>Mã BOM</label><input type="text" value="BOM001"></div>
+  <div>
+    <table>
+      <tr><th>SKU</th><th>Mô tả</th><th>Số lượng yêu cầu</th><th>ĐVT</th></tr>
+      <tr><td>VT001</td><td>Bulong M8</td><td><input type="number" value="4"></td><td>Cái</td></tr>
+      <tr><td>VT003</td><td>Thân máy</td><td><input type="number" value="1"></td><td>Bộ</td></tr>
+    </table>
+  </div>
+  <button type="submit">Gửi phê duyệt</button>
+</form>
+</body>
+</html>

--- a/code/mockup/request_issue_general.html
+++ b/code/mockup/request_issue_general.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>Lãnh vật tư kho chung</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h2>Lãnh vật tư kho chung</h2>
+<form>
+  <div>
+    <table>
+      <tr><th>SKU</th><th>Mô tả</th><th>Số lượng yêu cầu</th><th>ĐVT</th></tr>
+      <tr><td>VT005</td><td>Keo dán</td><td><input type="number" value="2"></td><td>Tuýp</td></tr>
+      <tr><td>VT006</td><td>Băng keo</td><td><input type="number" value="1"></td><td>Cái</td></tr>
+    </table>
+  </div>
+  <button type="submit">Gửi phê duyệt</button>
+</form>
+</body>
+</html>

--- a/code/mockup/style.css
+++ b/code/mockup/style.css
@@ -1,0 +1,7 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+header { margin-bottom: 20px; }
+nav a { margin-right: 10px; }
+table { border-collapse: collapse; width: 100%; margin-top: 10px; }
+th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+form div { margin-bottom: 10px; }
+

--- a/code/mockup/warehouses.html
+++ b/code/mockup/warehouses.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>Danh sách kho</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h2>Danh sách kho</h2>
+<table>
+  <tr><th>Mã kho</th><th>Tên kho</th><th>Địa điểm</th></tr>
+  <tr><td>WH1</td><td>Kho chính</td><td>Khu A</td></tr>
+  <tr><td>WH2</td><td>Kho thành phẩm</td><td>Khu B</td></tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold `code/mockup` with common navigation and base CSS
- add static mockups for login, dashboard, warehouse/bin lists, GRN/Issue forms, BOM screens, issue requests, PR/PO forms and inventory report

## Testing
- `ls code/mockup`

------
https://chatgpt.com/codex/tasks/task_e_6897eaae214883328fc74164046cb7dd