### PR TITLE
Fix cloned row duplication in mockup forms

### DIFF
--- a/code/mockup/bins.html
+++ b/code/mockup/bins.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Quản lý bin</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">DEMAX</a>
+  </div>
+</nav>
+<div class="container py-4">
+  <h2>Quản lý bin</h2>
+  <div class="table-responsive">
+    <table class="table table-bordered">
+      <thead>
+        <tr><th>Khu</th><th>Bin</th><th>Kho</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>A</td><td>A1</td><td>WH1</td></tr>
+        <tr><td>A</td><td>A2</td><td>WH1</td></tr>
+        <tr><td>B</td><td>B1</td><td>WH2</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/code/mockup/bom_detail.html
+++ b/code/mockup/bom_detail.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Chi tiết BOM</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">DEMAX</a>
+  </div>
+</nav>
+<div class="container py-4">
+  <h2>Chi tiết BOM: BOM001</h2>
+  <div class="table-responsive">
+    <table class="table table-bordered">
+      <thead>
+        <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>VT001</td><td>Bulong M8</td><td>4</td><td>Cái</td></tr>
+        <tr><td>VT003</td><td>Thân máy</td><td>1</td><td>Bộ</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/code/mockup/bom_list.html
+++ b/code/mockup/bom_list.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Danh sách BOM</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">DEMAX</a>
+  </div>
+</nav>
+<div class="container py-4">
+  <h2>Danh sách BOM</h2>
+  <div class="table-responsive">
+    <table class="table table-bordered">
+      <thead>
+        <tr><th>Mã BOM</th><th>Tên BOM</th><th>Phiên bản</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>BOM001</td><td>Máy A</td><td>v1</td></tr>
+        <tr><td>BOM002</td><td>Máy B</td><td>v2</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/code/mockup/dashboard.html
+++ b/code/mockup/dashboard.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dashboard</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">DEMAX</a>
+  </div>
+</nav>
+<div class="container py-4">
+  <h2 class="mb-4">Dashboard</h2>
+  <div class="row g-3">
+    <div class="col-md-4">
+      <div class="card text-center">
+        <div class="card-body">
+          <p class="card-text">Phiếu nhập chờ duyệt</p>
+          <h3>3</h3>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="card text-center">
+        <div class="card-body">
+          <p class="card-text">Phiếu xuất chờ duyệt</p>
+          <h3>2</h3>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="card text-center">
+        <div class="card-body">
+          <p class="card-text">SKU dưới min</p>
+          <h3>5</h3>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/code/mockup/grn_form.html
+++ b/code/mockup/grn_form.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Phiếu nhập (GRN)</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">DEMAX</a>
+  </div>
+</nav>
+<div class="container py-4">
+  <h2>Phiếu nhập (GRN)</h2>
+  <form class="mt-3">
+    <div class="mb-3"><label class="form-label">Quét mã</label><input type="text" class="form-control" placeholder="Scan barcode or QR"></div>
+    <div class="row mb-3">
+      <div class="col-md-6">
+        <label class="form-label">Nhà cung cấp</label>
+        <input type="text" class="form-control" value="NCC ABC">
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">Ngày nhập</label>
+        <input type="date" class="form-control" value="2025-05-01">
+      </div>
+    </div>
+    <div class="table-responsive mb-3">
+      <table class="table table-bordered" id="grnItems">
+        <thead>
+          <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th></tr>
+        </thead>
+        <tbody>
+          <tr class="item-row"><td>VT001</td><td>Bulong M8</td><td><input type="number" class="form-control" value="100"></td><td>Cái</td></tr>
+          <tr class="item-row"><td>VT002</td><td>Đai ốc M8</td><td><input type="number" class="form-control" value="100"></td><td>Cái</td></tr>
+        </tbody>
+      </table>
+      <button type="button" class="btn btn-secondary add-row" data-target="#grnItems">+ Thêm dòng</button>
+    </div>
+    <button type="submit" class="btn btn-accent">Gửi phê duyệt</button>
+  </form>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/code/mockup/index.html
+++ b/code/mockup/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>DEMAX Mockups</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">DEMAX</a>
+  </div>
+</nav>
+<div class="container py-4">
+  <h1 class="mb-4">DEMAX Inventory Mockups</h1>
+  <div class="list-group">
+    <a href="login.html" class="list-group-item list-group-item-action">Đăng nhập</a>
+    <a href="dashboard.html" class="list-group-item list-group-item-action">Dashboard</a>
+    <a href="warehouses.html" class="list-group-item list-group-item-action">Danh sách kho</a>
+    <a href="bins.html" class="list-group-item list-group-item-action">Quản lý bin</a>
+    <a href="grn_form.html" class="list-group-item list-group-item-action">Phiếu nhập (GRN)</a>
+    <a href="issue_form.html" class="list-group-item list-group-item-action">Phiếu xuất (Issue)</a>
+    <a href="bom_list.html" class="list-group-item list-group-item-action">Danh sách BOM</a>
+    <a href="bom_detail.html" class="list-group-item list-group-item-action">Chi tiết BOM</a>
+    <a href="request_issue_bom.html" class="list-group-item list-group-item-action">Lãnh theo BOM</a>
+    <a href="request_issue_general.html" class="list-group-item list-group-item-action">Lãnh kho chung</a>
+    <a href="pr_form.html" class="list-group-item list-group-item-action">Phiếu yêu cầu mua (PR)</a>
+    <a href="po_form.html" class="list-group-item list-group-item-action">Đơn mua hàng (PO)</a>
+    <a href="report_inventory.html" class="list-group-item list-group-item-action">Báo cáo tồn kho</a>
+  </div>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/code/mockup/issue_form.html
+++ b/code/mockup/issue_form.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Phiếu xuất (Issue)</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">DEMAX</a>
+  </div>
+</nav>
+<div class="container py-4">
+  <h2>Phiếu xuất (Issue)</h2>
+  <form class="mt-3">
+    <div class="mb-3"><label class="form-label">Quét mã</label><input type="text" class="form-control" placeholder="Scan barcode or QR"></div>
+    <div class="row mb-3">
+      <div class="col-md-6">
+        <label class="form-label">Kho xuất</label>
+        <input type="text" class="form-control" value="WH1">
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">Ngày xuất</label>
+        <input type="date" class="form-control" value="2025-05-02">
+      </div>
+    </div>
+    <div class="table-responsive mb-3">
+      <table class="table table-bordered" id="issueItems">
+        <thead>
+          <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th></tr>
+        </thead>
+        <tbody>
+          <tr class="item-row"><td>VT001</td><td>Bulong M8</td><td><input type="number" class="form-control" value="50"></td><td>Cái</td></tr>
+        </tbody>
+      </table>
+      <button type="button" class="btn btn-secondary add-row" data-target="#issueItems">+ Thêm dòng</button>
+    </div>
+    <button type="submit" class="btn btn-accent">Gửi phê duyệt</button>
+  </form>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/code/mockup/login.html
+++ b/code/mockup/login.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Đăng nhập</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">DEMAX</a>
+  </div>
+</nav>
+<div class="d-flex justify-content-center align-items-center vh-100">
+  <div class="card border-primary p-4" style="min-width:300px;">
+    <h2 class="mb-3 text-center">Đăng nhập</h2>
+    <form>
+      <div class="mb-3">
+        <label class="form-label">Tên đăng nhập</label>
+        <input type="text" class="form-control" value="receiver1">
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Mật khẩu</label>
+        <input type="password" class="form-control" value="password">
+      </div>
+      <button type="submit" class="btn btn-accent w-100">Login</button>
+    </form>
+  </div>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/code/mockup/po_form.html
+++ b/code/mockup/po_form.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Đơn mua hàng (PO)</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">DEMAX</a>
+  </div>
+</nav>
+<div class="container py-4">
+  <h2>Đơn mua hàng (PO)</h2>
+  <form class="mt-3">
+    <div class="mb-3"><label class="form-label">Quét mã</label><input type="text" class="form-control" placeholder="Scan barcode or QR"></div>
+    <div class="mb-3">
+      <label class="form-label">Nhà cung cấp</label>
+      <input type="text" class="form-control" value="NCC XYZ">
+    </div>
+    <div class="table-responsive mb-3">
+      <table class="table table-bordered" id="poItems">
+        <thead>
+          <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th><th>Đơn giá</th></tr>
+        </thead>
+        <tbody>
+          <tr class="item-row">
+            <td>VT007</td>
+            <td>Motor</td>
+            <td><input type="number" class="form-control" value="2"></td>
+            <td>Cái</td>
+            <td><input type="number" class="form-control" value="5000000"></td>
+          </tr>
+        </tbody>
+      </table>
+      <button type="button" class="btn btn-secondary add-row" data-target="#poItems">+ Thêm dòng</button>
+    </div>
+    <button type="submit" class="btn btn-accent">Trình ký</button>
+  </form>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/code/mockup/pr_form.html
+++ b/code/mockup/pr_form.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Phiếu yêu cầu mua (PR)</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">DEMAX</a>
+  </div>
+</nav>
+<div class="container py-4">
+  <h2>Phiếu yêu cầu mua (PR)</h2>
+  <form class="mt-3">
+    <div class="mb-3"><label class="form-label">Quét mã</label><input type="text" class="form-control" placeholder="Scan barcode or QR"></div>
+    <div class="mb-3">
+      <label class="form-label">Người yêu cầu</label>
+      <input type="text" class="form-control" value="NV001">
+    </div>
+    <div class="table-responsive mb-3">
+      <table class="table table-bordered" id="prItems">
+        <thead>
+          <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th></tr>
+        </thead>
+        <tbody>
+          <tr class="item-row"><td>VT007</td><td>Motor</td><td><input type="number" class="form-control" value="2"></td><td>Cái</td></tr>
+        </tbody>
+      </table>
+      <button type="button" class="btn btn-secondary add-row" data-target="#prItems">+ Thêm dòng</button>
+    </div>
+    <button type="submit" class="btn btn-accent">Gửi phê duyệt</button>
+  </form>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/code/mockup/report_inventory.html
+++ b/code/mockup/report_inventory.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Báo cáo tồn kho</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">DEMAX</a>
+  </div>
+</nav>
+<div class="container py-4">
+  <h2>Báo cáo tồn kho</h2>
+  <div class="table-responsive">
+    <table class="table table-bordered">
+      <thead>
+        <tr><th>SKU</th><th>Tên vật tư</th><th>Kho</th><th>Tồn</th><th>Min</th><th>Max</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>VT001</td><td>Bulong M8</td><td>WH1</td><td>80</td><td>50</td><td>200</td></tr>
+        <tr class="table-danger"><td>VT005</td><td>Keo dán</td><td>WH1</td><td>1</td><td>5</td><td>20</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/code/mockup/request_issue_bom.html
+++ b/code/mockup/request_issue_bom.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Lãnh vật tư theo BOM</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">DEMAX</a>
+  </div>
+</nav>
+<div class="container py-4">
+  <h2>Lãnh vật tư theo BOM</h2>
+  <form class="mt-3">
+    <div class="mb-3"><label class="form-label">Quét mã</label><input type="text" class="form-control" placeholder="Scan barcode or QR"></div>
+    <div class="mb-3">
+      <label class="form-label">Mã BOM</label>
+      <input type="text" class="form-control" value="BOM001">
+    </div>
+    <div class="table-responsive mb-3">
+      <table class="table table-bordered" id="bomIssueItems">
+        <thead>
+          <tr><th>SKU</th><th>Mô tả</th><th>Số lượng yêu cầu</th><th>ĐVT</th></tr>
+        </thead>
+        <tbody>
+          <tr class="item-row"><td>VT001</td><td>Bulong M8</td><td><input type="number" class="form-control" value="4"></td><td>Cái</td></tr>
+          <tr class="item-row"><td>VT003</td><td>Thân máy</td><td><input type="number" class="form-control" value="1"></td><td>Bộ</td></tr>
+        </tbody>
+      </table>
+      <button type="button" class="btn btn-secondary add-row" data-target="#bomIssueItems">+ Thêm dòng</button>
+    </div>
+    <button type="submit" class="btn btn-accent">Gửi phê duyệt</button>
+  </form>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/code/mockup/request_issue_general.html
+++ b/code/mockup/request_issue_general.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Lãnh vật tư kho chung</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">DEMAX</a>
+  </div>
+</nav>
+<div class="container py-4">
+  <h2>Lãnh vật tư kho chung</h2>
+  <form class="mt-3">
+    <div class="mb-3"><label class="form-label">Quét mã</label><input type="text" class="form-control" placeholder="Scan barcode or QR"></div>
+    <div class="table-responsive mb-3">
+      <table class="table table-bordered" id="generalIssueItems">
+        <thead>
+          <tr><th>SKU</th><th>Mô tả</th><th>Số lượng yêu cầu</th><th>ĐVT</th></tr>
+        </thead>
+        <tbody>
+          <tr class="item-row"><td>VT005</td><td>Keo dán</td><td><input type="number" class="form-control" value="2"></td><td>Tuýp</td></tr>
+          <tr class="item-row"><td>VT006</td><td>Băng keo</td><td><input type="number" class="form-control" value="1"></td><td>Cái</td></tr>
+        </tbody>
+      </table>
+      <button type="button" class="btn btn-secondary add-row" data-target="#generalIssueItems">+ Thêm dòng</button>
+    </div>
+    <button type="submit" class="btn btn-accent">Gửi phê duyệt</button>
+  </form>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/code/mockup/script.js
+++ b/code/mockup/script.js
@@ -1,0 +1,18 @@
+$(function () {
+  $('.add-row').on('click', function () {
+    const target = $($(this).data('target'));
+    const last = target.find('tr.item-row:last');
+    const clone = last.clone();
+    // Clear inputs and selects in the cloned row
+    clone.find('input, select, textarea').val('');
+    // Remove text from cells without form controls
+    clone
+      .find('td')
+      .filter(function () {
+        return $(this).find('input, select, textarea').length === 0;
+      })
+      .text('');
+    target.find('tbody').append(clone);
+  });
+});
+

--- a/code/mockup/style.css
+++ b/code/mockup/style.css
@@ -1,0 +1,29 @@
+:root {
+  --primary: #0E4F9E;
+  --secondary: #F5F5F5;
+  --accent: #16A34A;
+  --warning: #F59E0B;
+  --danger: #DC2626;
+  --text: #1F2937;
+}
+body {
+  font-family: Arial, sans-serif;
+  background-color: var(--secondary);
+  color: var(--text);
+}
+.navbar {
+  background-color: var(--primary) !important;
+}
+.navbar .navbar-brand { color: #fff; }
+.navbar .nav-link { color: #fff; }
+.btn-accent {
+  background-color: var(--accent);
+  color: #fff;
+}
+.btn-accent:hover {
+  background-color: #128636;
+  color: #fff;
+}
+.table td, .table th { vertical-align: middle; }
+.table input { width: 100%; }
+.add-row { margin-top: 0.5rem; }

--- a/code/mockup/warehouses.html
+++ b/code/mockup/warehouses.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Danh sách kho</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">DEMAX</a>
+  </div>
+</nav>
+<div class="container py-4">
+  <h2>Danh sách kho</h2>
+  <div class="table-responsive">
+    <table class="table table-bordered">
+      <thead>
+        <tr><th>Mã kho</th><th>Tên kho</th><th>Địa điểm</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>WH1</td><td>Kho chính</td><td>Khu A</td></tr>
+        <tr><td>WH2</td><td>Kho thành phẩm</td><td>Khu B</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/document/UIUX_DESIGNER.md
+++ b/document/UIUX_DESIGNER.md
@@ -1,0 +1,108 @@
+# Định hướng UI/UX DEMAX Inventory
+
+## 1. Mục tiêu
+Tài liệu định hướng phong cách màu sắc và bố cục cho các màn hình của hệ thống DEMAX Inventory, nhằm bảo đảm giao diện thống nhất, dễ sử dụng và hỗ trợ thao tác nhanh theo yêu cầu trong SRS.
+
+## 2. Bảng màu chủ đạo
+| Màu | Mã | Sử dụng |
+|-----|----|---------|
+| Primary | #0E4F9E | Thanh điều hướng, tiêu đề chính |
+| Secondary | #F5F5F5 | Nền nội dung, vùng nhập liệu |
+| Accent | #16A34A | Trạng thái thành công, nút hành động chính |
+| Warning | #F59E0B | Cảnh báo, tồn kho dưới Min |
+| Danger | #DC2626 | Lỗi, thao tác xoá |
+| Text | #1F2937 | Màu chữ chính |
+
+## 3. Bố cục chung
+- Ứng dụng Web SPA với thanh điều hướng trên (logo, tên người dùng, phím tắt) và menu bên trái.
+- Vùng nội dung trung tâm hiển thị bảng dữ liệu hoặc form theo module.
+- Tất cả form đặt ô quét Barcode/QR nổi bật ở đầu để đáp ứng yêu cầu thao tác nhanh.
+- Các bảng dữ liệu có hàng kẻ nhạt, thanh tìm kiếm và bộ lọc phía trên.
+- Badge màu cho trạng thái (Accent/Warning/Danger) giúp người dùng nhận biết.
+
+## 4. Định hướng theo màn hình
+### 4.1 Đăng nhập
+- Nền Secondary phủ toàn màn hình, card đăng nhập trung tâm với viền Primary.
+- Logo DEMAX phía trên, nút đăng nhập màu Accent; thông báo lỗi dùng màu Danger.
+
+### 4.2 Dashboard
+- Thẻ thống kê tóm tắt (Accent cho số liệu tốt, Warning cho tồn kho thấp).
+- Biểu đồ tiến trình phiếu đặt ở phần trên; danh sách tác vụ gần đây bên dưới.
+
+### 4.3 Layout chung & Navigation
+- Sidebar nền Primary đậm với icon trắng; mục đang chọn dùng nền sáng hơn.
+- Nội dung hiển thị dạng grid 12 cột, khoảng cách 16px.
+
+### 4.4 Danh sách kho
+- Bảng toàn trang, cột lọc bên phải.
+- Nút "Tạo kho" màu Accent ở góc trên.
+
+### 4.5 Form tạo/sửa kho
+- Form hai cột, trường bắt buộc đánh dấu đỏ.
+- Có tab "Thông tin chung" và "Địa điểm".
+
+### 4.6 Quản lý bin
+- Cây thư mục bên trái thể hiện khu/bin, bảng chi tiết bên phải.
+- Màu Primary nhạt đánh dấu bin đang chọn.
+
+### 4.7 Danh sách vật tư
+- Bảng với ảnh nhỏ 40x40, bộ lọc theo nhóm và kho.
+- Badge màu cảnh báo khi tồn < Min.
+
+### 4.8 Form tạo/sửa vật tư
+- Sử dụng các tab: Thông tin, BOM, Nhà cung cấp.
+- Ô nhập mã SKU nằm đầu form, hỗ trợ quét.
+
+### 4.9 Form nhập (GRN)
+- Wizard 3 bước: Thông tin phiếu → Dòng vật tư → Xác nhận.
+- Nút "Quét" màu Accent, cảnh báo màu Warning khi thiếu chứng từ.
+
+### 4.10 Form xuất (Issue)
+- Bố cục giống GRN, bổ sung trường "Phiếu lãnh".
+- Màu Danger cho dòng xuất vượt tồn.
+
+### 4.11 Form điều chuyển
+- Hai cột song song: Kho nguồn và Kho đích.
+- Màu Primary cho kho nguồn, Accent cho kho đích.
+
+### 4.12 Danh sách BOM
+- Bảng với khả năng mở rộng (accordion) để xem các vật tư con.
+- Nút "Tạo BOM" đặt cố định ở góc dưới bên phải.
+
+### 4.13 Chi tiết BOM
+- Sơ đồ cây hiển thị cấp cha-con, mỗi cấp thụt 16px.
+- Badge màu Warning khi thiếu vật tư hoặc chưa duyệt.
+
+### 4.14 Yêu cầu lãnh vật tư
+- Form dạng wizard theo quy trình duyệt.
+- Thẻ trạng thái cho từng bước duyệt sử dụng Accent/Warning/Danger.
+
+### 4.15 Phiếu yêu cầu mua (PR)
+- Form nhiều phần: Thông tin, Dòng vật tư, Đính kèm.
+- Dòng vật tư hiển thị màu Warning nếu vượt ngưỡng Min.
+
+### 4.16 Đơn mua hàng (PO)
+- Bố cục kế thừa từ PR, bổ sung trường Nhà cung cấp.
+- Khi PO đã phát hành, banner nền Primary nhạt hiển thị số PO.
+
+### 4.17 Báo cáo nhập–xuất–tồn
+- Bộ lọc nằm trên, kết quả dạng bảng và biểu đồ cột.
+- Sử dụng Accent cho dòng nhập, Danger cho dòng xuất.
+
+### 4.18 Đồ thị thiếu hụt theo BOM
+- Biểu đồ line/area màu Danger thể hiện chênh lệch, đường chuẩn màu Primary.
+
+### 4.19 Báo cáo tuổi tồn
+- Bảng phân nhóm theo tuổi; ô màu Warning khi > 6 tháng, Danger khi > 12 tháng.
+
+### 4.20 Truy vết lô/serial
+- Thanh tìm kiếm trên cùng, kết quả dạng timeline.
+- Màu Accent cho trạng thái đã nhập, Primary cho đang lưu kho, Danger cho đã xuất.
+
+### 4.21 Phân quyền hiển thị
+- Các menu và nút ẩn/hiện tuỳ vai trò; sử dụng badge nhỏ hiển thị vai trò hiện tại trên header.
+
+## 5. Tài liệu tham chiếu
+- [README.md](../README.md)
+- [SRS_Kho_DEMAX_2025-08-09_fixed.docx](../SRS_Kho_DEMAX_2025-08-09_fixed.docx)
+- [SCREEN_TASKS.md](SCREEN_TASKS.md)


### PR DESCRIPTION
## Summary
- Clear inputs and text-only cells when duplicating table rows in mockup forms

## Testing
- `npx -y htmlhint code/mockup/*.html` *(fails: 403 Forbidden to registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_6897eaae214883328fc74164046cb7dd