### PR TITLE
feat: add missing inventory mockups

### DIFF
--- a/code/mockup/bom_form.html
+++ b/code/mockup/bom_form.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Tạo/Sửa BOM</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+<h2>Tạo/Sửa BOM</h2>
+<form>
+  <div><label>Mã BOM</label><input type="text" value="BOM002"></div>
+  <div><label>Mô tả</label><input type="text" value="BOM demo"></div>
+  <div>
+    <table>
+      <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th></tr>
+      <tr><td><input type="text" value="VT001"></td><td>Bulong M8</td><td><input type="number" value="4"></td><td>Cái</td></tr>
+      <tr><td><input type="text" value="VT003"></td><td>Thân máy</td><td><input type="number" value="1"></td><td>Bộ</td></tr>
+    </table>
+  </div>
+  <button type="submit">Lưu</button>
+</form>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/code/mockup/index.html
+++ b/code/mockup/index.html
@@ -22,8 +22,12 @@
       <a href="bins.html" class="list-group-item list-group-item-action">Quản lý bin</a>
       <a href="grn_form.html" class="list-group-item list-group-item-action">Phiếu nhập (GRN)</a>
       <a href="issue_form.html" class="list-group-item list-group-item-action">Phiếu xuất (Issue)</a>
+      <a href="transfer_form.html" class="list-group-item list-group-item-action">Điều chuyển nội bộ</a>
+      <a href="stocktake_form.html" class="list-group-item list-group-item-action">Phiếu kiểm kê</a>
+      <a href="return_form.html" class="list-group-item list-group-item-action">Phiếu trả hàng</a>
       <a href="bom_list.html" class="list-group-item list-group-item-action">Danh sách BOM</a>
       <a href="bom_detail.html" class="list-group-item list-group-item-action">Chi tiết BOM</a>
+      <a href="bom_form.html" class="list-group-item list-group-item-action">Tạo/Sửa BOM</a>
       <a href="request_issue_bom.html" class="list-group-item list-group-item-action">Lãnh theo BOM</a>
       <a href="request_issue_general.html" class="list-group-item list-group-item-action">Lãnh kho chung</a>
       <a href="pr_form.html" class="list-group-item list-group-item-action">Phiếu yêu cầu mua (PR)</a>

--- a/code/mockup/return_form.html
+++ b/code/mockup/return_form.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Phiếu trả hàng</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+<h2>Phiếu trả hàng</h2>
+<form>
+  <div><label>Đối tượng trả</label><input type="text" value="Kho sản xuất"></div>
+  <div><label>Lý do</label><input type="text" value="Thừa vật tư"></div>
+  <div>
+    <table>
+      <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th></tr>
+      <tr><td>VT001</td><td>Bulong M8</td><td><input type="number" value="10"></td><td>Cái</td></tr>
+    </table>
+  </div>
+  <button type="submit">Gửi phê duyệt</button>
+</form>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/code/mockup/stocktake_form.html
+++ b/code/mockup/stocktake_form.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Phiếu kiểm kê</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+<h2>Phiếu kiểm kê</h2>
+<form>
+  <div><label>Kho</label><input type="text" value="Kho A"></div>
+  <div>
+    <table>
+      <tr><th>SKU</th><th>Mô tả</th><th>Tồn hệ thống</th><th>Thực tế</th><th>Chênh lệch</th></tr>
+      <tr><td>VT001</td><td>Bulong M8</td><td>100</td><td><input type="number" value="98"></td><td>-2</td></tr>
+    </table>
+  </div>
+  <button type="submit">Gửi phê duyệt</button>
+</form>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/code/mockup/transfer_form.html
+++ b/code/mockup/transfer_form.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Phiếu điều chuyển nội bộ</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+<h2>Phiếu điều chuyển nội bộ</h2>
+<form>
+  <div><label>Kho nguồn</label><input type="text" value="Kho A"></div>
+  <div><label>Kho đích</label><input type="text" value="Kho B"></div>
+  <div>
+    <table>
+      <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th></tr>
+      <tr><td>VT001</td><td>Bulong M8</td><td><input type="number" value="50"></td><td>Cái</td></tr>
+    </table>
+  </div>
+  <button type="submit">Gửi phê duyệt</button>
+</form>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add mockups for internal transfer, stocktake, returns, and BOM form
- expose new screens via main mockup index

## Testing
- `npm test` (fails: Could not read package.json)
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68982904759c8332ba6d3e111a4e90dc