### PR TITLE
feat(mockup): add approval screens

### DIFF
--- a/code/mockup/grn_approval.html
+++ b/code/mockup/grn_approval.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Duyệt phiếu nhập (GRN)</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+    <h2>Duyệt phiếu nhập (GRN)</h2>
+    <form>
+      <div><label>Nhà cung cấp</label><input type="text" value="NCC ABC" readonly></div>
+      <div><label>Ngày nhập</label><input type="date" value="2025-05-01" readonly></div>
+      <div>
+        <table>
+          <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th></tr>
+          <tr><td>VT001</td><td>Bulong M8</td><td>100</td><td>Cái</td></tr>
+          <tr><td>VT002</td><td>Đai ốc M8</td><td>100</td><td>Cái</td></tr>
+        </table>
+      </div>
+      <button type="submit" class="btn btn-success">Phê duyệt</button>
+      <button type="button" class="btn btn-danger">Từ chối</button>
+    </form>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/code/mockup/index.html
+++ b/code/mockup/index.html
@@ -21,17 +21,24 @@
       <a href="warehouses.html" class="list-group-item list-group-item-action">Danh sách kho</a>
       <a href="bins.html" class="list-group-item list-group-item-action">Quản lý bin</a>
       <a href="grn_form.html" class="list-group-item list-group-item-action">Phiếu nhập (GRN)</a>
+      <a href="grn_approval.html" class="list-group-item list-group-item-action">Duyệt phiếu nhập</a>
       <a href="issue_form.html" class="list-group-item list-group-item-action">Phiếu xuất (Issue)</a>
+      <a href="issue_approval.html" class="list-group-item list-group-item-action">Duyệt phiếu xuất</a>
       <a href="transfer_form.html" class="list-group-item list-group-item-action">Điều chuyển nội bộ</a>
+      <a href="transfer_approval.html" class="list-group-item list-group-item-action">Duyệt điều chuyển</a>
       <a href="stocktake_form.html" class="list-group-item list-group-item-action">Phiếu kiểm kê</a>
+      <a href="stocktake_approval.html" class="list-group-item list-group-item-action">Duyệt phiếu kiểm kê</a>
       <a href="return_form.html" class="list-group-item list-group-item-action">Phiếu trả hàng</a>
+      <a href="return_approval.html" class="list-group-item list-group-item-action">Duyệt phiếu trả hàng</a>
       <a href="bom_list.html" class="list-group-item list-group-item-action">Danh sách BOM</a>
       <a href="bom_detail.html" class="list-group-item list-group-item-action">Chi tiết BOM</a>
       <a href="bom_form.html" class="list-group-item list-group-item-action">Tạo/Sửa BOM</a>
       <a href="request_issue_bom.html" class="list-group-item list-group-item-action">Lãnh theo BOM</a>
       <a href="request_issue_general.html" class="list-group-item list-group-item-action">Lãnh kho chung</a>
       <a href="pr_form.html" class="list-group-item list-group-item-action">Phiếu yêu cầu mua (PR)</a>
+      <a href="pr_approval.html" class="list-group-item list-group-item-action">Duyệt phiếu yêu cầu mua</a>
       <a href="po_form.html" class="list-group-item list-group-item-action">Đơn mua hàng (PO)</a>
+      <a href="po_approval.html" class="list-group-item list-group-item-action">Duyệt đơn mua hàng</a>
       <a href="report_inventory.html" class="list-group-item list-group-item-action">Báo cáo tồn kho</a>
     </div>
   </div>

--- a/code/mockup/issue_approval.html
+++ b/code/mockup/issue_approval.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Duyệt phiếu xuất (Issue)</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+    <h2>Duyệt phiếu xuất (Issue)</h2>
+    <form>
+      <div><label>Kho xuất</label><input type="text" value="Kho Tổng" readonly></div>
+      <div><label>Ngày xuất</label><input type="date" value="2025-05-02" readonly></div>
+      <div>
+        <table>
+          <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th></tr>
+          <tr><td>VT003</td><td>Thép tấm</td><td>50</td><td>Tấm</td></tr>
+          <tr><td>VT004</td><td>Sơn đỏ</td><td>10</td><td>Lon</td></tr>
+        </table>
+      </div>
+      <button type="submit" class="btn btn-success">Phê duyệt</button>
+      <button type="button" class="btn btn-danger">Từ chối</button>
+    </form>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/code/mockup/po_approval.html
+++ b/code/mockup/po_approval.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Duyệt đơn mua hàng (PO)</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+    <h2>Duyệt đơn mua hàng (PO)</h2>
+    <form>
+      <div><label>Nhà cung cấp</label><input type="text" value="NCC XYZ" readonly></div>
+      <div>
+        <table>
+          <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th></tr>
+          <tr><td>VT011</td><td>Mô tơ</td><td>2</td><td>Cái</td></tr>
+          <tr><td>VT012</td><td>Băng tải</td><td>1</td><td>Bộ</td></tr>
+        </table>
+      </div>
+      <button type="submit" class="btn btn-success">Phê duyệt</button>
+      <button type="button" class="btn btn-danger">Từ chối</button>
+    </form>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/code/mockup/pr_approval.html
+++ b/code/mockup/pr_approval.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Duyệt phiếu yêu cầu mua (PR)</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+    <h2>Duyệt phiếu yêu cầu mua (PR)</h2>
+    <form>
+      <div><label>Người yêu cầu</label><input type="text" value="NV A" readonly></div>
+      <div>
+        <table>
+          <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th></tr>
+          <tr><td>VT011</td><td>Mô tơ</td><td>2</td><td>Cái</td></tr>
+          <tr><td>VT012</td><td>Băng tải</td><td>1</td><td>Bộ</td></tr>
+        </table>
+      </div>
+      <button type="submit" class="btn btn-success">Phê duyệt</button>
+      <button type="button" class="btn btn-danger">Từ chối</button>
+    </form>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/code/mockup/return_approval.html
+++ b/code/mockup/return_approval.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Duyệt phiếu trả hàng</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+    <h2>Duyệt phiếu trả hàng</h2>
+    <form>
+      <div><label>Người trả</label><input type="text" value="NV Sản xuất" readonly></div>
+      <div>
+        <table>
+          <tr><th>SKU</th><th>Mô tả</th><th>Số lượng trả</th><th>ĐVT</th></tr>
+          <tr><td>VT009</td><td>Bu lông</td><td>10</td><td>Cái</td></tr>
+          <tr><td>VT010</td><td>Găng tay</td><td>5</td><td>Đôi</td></tr>
+        </table>
+      </div>
+      <button type="submit" class="btn btn-success">Phê duyệt</button>
+      <button type="button" class="btn btn-danger">Từ chối</button>
+    </form>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/code/mockup/stocktake_approval.html
+++ b/code/mockup/stocktake_approval.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Duyệt phiếu kiểm kê</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+    <h2>Duyệt phiếu kiểm kê</h2>
+    <form>
+      <div>
+        <table>
+          <tr><th>SKU</th><th>Tồn hệ thống</th><th>Tồn thực tế</th><th>Chênh lệch</th></tr>
+          <tr><td>VT007</td><td>100</td><td>98</td><td>-2</td></tr>
+          <tr><td>VT008</td><td>50</td><td>55</td><td>+5</td></tr>
+        </table>
+      </div>
+      <button type="submit" class="btn btn-success">Phê duyệt</button>
+      <button type="button" class="btn btn-danger">Từ chối</button>
+    </form>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/code/mockup/transfer_approval.html
+++ b/code/mockup/transfer_approval.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Duyệt điều chuyển nội bộ</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+    <h2>Duyệt điều chuyển nội bộ</h2>
+    <form>
+      <div><label>Kho nguồn</label><input type="text" value="Kho A" readonly></div>
+      <div><label>Kho đích</label><input type="text" value="Kho B" readonly></div>
+      <div>
+        <table>
+          <tr><th>SKU</th><th>Mô tả</th><th>Số lượng</th><th>ĐVT</th></tr>
+          <tr><td>VT005</td><td>Ống thép</td><td>20</td><td>Cây</td></tr>
+          <tr><td>VT006</td><td>Dây điện</td><td>100</td><td>m</td></tr>
+        </table>
+      </div>
+      <button type="submit" class="btn btn-success">Phê duyệt</button>
+      <button type="button" class="btn btn-danger">Từ chối</button>
+    </form>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/document/MOCKUP_TASKS.md
+++ b/document/MOCKUP_TASKS.md
@@ -1,17 +1,27 @@
 # Breakdown công việc: Tạo mockup HTML (An)
 
-- [ ] Tạo cấu trúc thư mục và file HTML/CSS mẫu
-- [ ] Mock màn hình đăng nhập
-- [ ] Mock màn hình dashboard
-- [ ] Mock màn hình danh sách kho
-- [ ] Mock màn hình quản lý bin
-- [ ] Mock form nhập (GRN)
-- [ ] Mock form xuất (Issue)
-- [ ] Mock danh sách BOM
-- [ ] Mock chi tiết BOM
-- [ ] Mock màn hình yêu cầu lãnh vật tư theo BOM
-- [ ] Mock màn hình yêu cầu lãnh vật tư chung
-- [ ] Mock màn hình phiếu yêu cầu mua (PR)
-- [ ] Mock màn hình đơn mua hàng (PO)
-- [ ] Mock màn hình báo cáo tồn kho
+- [x] Tạo cấu trúc thư mục và file HTML/CSS mẫu
+- [x] Mock màn hình đăng nhập
+- [x] Mock màn hình dashboard
+- [x] Mock màn hình danh sách kho
+- [x] Mock màn hình quản lý bin
+- [x] Mock form nhập (GRN)
+- [x] Mock form xuất (Issue)
+- [x] Mock phiếu điều chuyển nội bộ
+- [x] Mock phiếu kiểm kê
+- [x] Mock phiếu trả hàng
+- [x] Mock danh sách BOM
+- [x] Mock chi tiết BOM
+- [x] Mock màn hình yêu cầu lãnh vật tư theo BOM
+- [x] Mock màn hình yêu cầu lãnh vật tư chung
+- [x] Mock màn hình phiếu yêu cầu mua (PR)
+- [x] Mock màn hình đơn mua hàng (PO)
+- [x] Mock màn hình báo cáo tồn kho
+- [x] Mock màn hình duyệt phiếu nhập (GRN)
+- [x] Mock màn hình duyệt phiếu xuất (Issue)
+- [x] Mock màn hình duyệt phiếu điều chuyển
+- [x] Mock màn hình duyệt phiếu kiểm kê
+- [x] Mock màn hình duyệt phiếu trả hàng
+- [x] Mock màn hình duyệt phiếu yêu cầu mua (PR)
+- [x] Mock màn hình duyệt đơn mua hàng (PO)
 - [ ] Review mockup với stakeholder và cập nhật


### PR DESCRIPTION
## Summary
- Add approval mockup pages for GRN, Issue, Transfer, Stocktake, Return, PR and PO flows
- Link new approval pages in the mockup index and update the task checklist

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68982be2ed3883328b955fb0ed46af30