### PR TITLE
docs: map mockup screens to business requirements

### DIFF
--- a/MOCKUP_CODE_MAPPING.md
+++ b/MOCKUP_CODE_MAPPING.md
@@ -1,0 +1,36 @@
+# Mockup Code Mapping
+
+This document links each UI mockup with the relevant business requirement section in the SRS summary (`README.md`).
+
+| Mockup file | Screen / Feature | Business requirement reference |
+|-------------|-----------------|--------------------------------|
+| login.html | Đăng nhập hệ thống | §6.1 Phân quyền – quản lý vai trò và đăng nhập【F:README.md†L194-L197】 |
+| dashboard.html | Dashboard tiến trình | §3 Yêu cầu UI/UX – Dashboard theo dõi tiến trình phiếu【F:README.md†L55-L59】 |
+| warehouses.html | Danh sách kho | §4.1 Danh mục chính – Kho【F:README.md†L61-L63】 |
+| bins.html | Quản lý bin/khu | §4.1 Danh mục chính – Khu/Bin【F:README.md†L61-L63】 |
+| items.html | Danh sách vật tư | §4.1 Danh mục chính – Vật tư (SKU)【F:README.md†L61-L63】 |
+| item_groups.html | Nhóm vật tư | §4.1 Danh mục chính – Nhóm vật tư【F:README.md†L61-L63】 |
+| uoms.html | Đơn vị tính | §4.1 Danh mục chính – ĐVT (UoM)【F:README.md†L61-L63】 |
+| suppliers.html | Nhà cung cấp | §4.1 Danh mục chính – Nhà cung cấp【F:README.md†L61-L63】 |
+| users.html | Người dùng | §4.1 Danh mục chính – Người dùng & Vai trò【F:README.md†L61-L63】 |
+| roles.html | Vai trò | §4.1 Danh mục chính – Người dùng & Vai trò【F:README.md†L61-L63】 |
+| grn_form.html | Tạo phiếu nhập (GRN) | §5.1 Quản lý kho & nhập/xuất – Nhập kho【F:README.md†L71-L75】 |
+| grn_approval.html | Duyệt phiếu nhập | §5.1 Quản lý kho & nhập/xuất – Nhập kho (duyệt)【F:README.md†L71-L75】 |
+| issue_form.html | Tạo phiếu xuất (Issue) | §5.1 Quản lý kho & nhập/xuất – Xuất kho【F:README.md†L71-L75】 |
+| issue_approval.html | Duyệt phiếu xuất | §5.1 Quản lý kho & nhập/xuất – Xuất kho (duyệt)【F:README.md†L71-L75】 |
+| transfer_form.html | Tạo phiếu điều chuyển | §5.1 Quản lý kho & nhập/xuất – Điều chuyển nội bộ【F:README.md†L71-L75】 |
+| transfer_approval.html | Duyệt điều chuyển | §5.1 Quản lý kho & nhập/xuất – Điều chuyển nội bộ (duyệt)【F:README.md†L71-L75】 |
+| stocktake_form.html | Tạo phiếu kiểm kê | §5.1 Quản lý kho & nhập/xuất – Kiểm kê & điều chỉnh【F:README.md†L71-L75】 |
+| stocktake_approval.html | Duyệt phiếu kiểm kê | §5.1 Quản lý kho & nhập/xuất – Kiểm kê & điều chỉnh (duyệt)【F:README.md†L71-L75】 |
+| return_form.html | Tạo phiếu trả hàng | §5.1 Quản lý kho & nhập/xuất – Trả hàng【F:README.md†L71-L75】 |
+| return_approval.html | Duyệt phiếu trả hàng | §5.1 Quản lý kho & nhập/xuất – Trả hàng (duyệt)【F:README.md†L71-L75】 |
+| bom_list.html | Danh sách BOM | §5.2 Quản lý BOM【F:README.md†L130-L134】 |
+| bom_detail.html | Chi tiết BOM | §5.2 Quản lý BOM【F:README.md†L130-L134】 |
+| bom_form.html | Tạo/Sửa BOM | §5.2 Quản lý BOM【F:README.md†L130-L134】 |
+| request_issue_bom.html | Lãnh theo BOM | §5.3 Lãnh vật tư theo BOM/kho chung【F:README.md†L148-L153】 |
+| request_issue_general.html | Lãnh kho chung | §5.3 Lãnh vật tư theo BOM/kho chung【F:README.md†L148-L153】 |
+| pr_form.html | Phiếu yêu cầu mua (PR) | §5.4 Thu mua【F:README.md†L169-L172】 |
+| pr_approval.html | Duyệt phiếu yêu cầu mua | §5.4 Thu mua (duyệt)【F:README.md†L169-L172】 |
+| po_form.html | Đơn mua hàng (PO) | §5.4 Thu mua【F:README.md†L169-L172】 |
+| po_approval.html | Duyệt đơn mua | §5.4 Thu mua (duyệt)【F:README.md†L169-L172】 |
+| report_inventory.html | Báo cáo tồn kho | §5.5 Báo cáo【F:README.md†L191-L192】 |

--- a/code/mockup/index.html
+++ b/code/mockup/index.html
@@ -20,6 +20,12 @@
       <a href="dashboard.html" class="list-group-item list-group-item-action">Dashboard</a>
       <a href="warehouses.html" class="list-group-item list-group-item-action">Danh sách kho</a>
       <a href="bins.html" class="list-group-item list-group-item-action">Quản lý bin</a>
+      <a href="items.html" class="list-group-item list-group-item-action">Danh sách vật tư</a>
+      <a href="item_groups.html" class="list-group-item list-group-item-action">Nhóm vật tư</a>
+      <a href="uoms.html" class="list-group-item list-group-item-action">Đơn vị tính</a>
+      <a href="suppliers.html" class="list-group-item list-group-item-action">Nhà cung cấp</a>
+      <a href="users.html" class="list-group-item list-group-item-action">Người dùng</a>
+      <a href="roles.html" class="list-group-item list-group-item-action">Vai trò</a>
       <a href="grn_form.html" class="list-group-item list-group-item-action">Phiếu nhập (GRN)</a>
       <a href="grn_approval.html" class="list-group-item list-group-item-action">Duyệt phiếu nhập</a>
       <a href="issue_form.html" class="list-group-item list-group-item-action">Phiếu xuất (Issue)</a>

--- a/code/mockup/item_groups.html
+++ b/code/mockup/item_groups.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Nhóm vật tư</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h2 class="mb-0">Nhóm vật tư</h2>
+      <button class="btn btn-success">Tạo nhóm</button>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-striped">
+        <thead class="table-light">
+          <tr><th>Mã</th><th>Tên</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>NL</td><td>Nguyên liệu</td></tr>
+          <tr><td>VT</td><td>Vật tư phụ</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/code/mockup/items.html
+++ b/code/mockup/items.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Danh sách vật tư</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h2 class="mb-0">Danh sách vật tư</h2>
+      <button class="btn btn-success">Tạo vật tư</button>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-striped">
+        <thead class="table-light">
+          <tr><th>Mã</th><th>Tên</th><th>ĐVT</th><th>Nhóm</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>VT001</td><td>Thép tấm</td><td>Tấm</td><td>Nguyên liệu</td></tr>
+          <tr><td>VT002</td><td>Sơn đỏ</td><td>Lon</td><td>Hoá chất</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/code/mockup/roles.html
+++ b/code/mockup/roles.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Vai trò</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h2 class="mb-0">Vai trò</h2>
+      <button class="btn btn-success">Tạo vai trò</button>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-striped">
+        <thead class="table-light">
+          <tr><th>Tên vai trò</th><th>Mô tả</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Kho</td><td>Quản lý kho</td></tr>
+          <tr><td>Sản xuất</td><td>Nhân viên sản xuất</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/code/mockup/suppliers.html
+++ b/code/mockup/suppliers.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Nhà cung cấp</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h2 class="mb-0">Nhà cung cấp</h2>
+      <button class="btn btn-success">Thêm NCC</button>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-striped">
+        <thead class="table-light">
+          <tr><th>Mã</th><th>Tên</th><th>Liên hệ</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>NCC01</td><td>Công ty A</td><td>0123456789</td></tr>
+          <tr><td>NCC02</td><td>Công ty B</td><td>0987654321</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/code/mockup/uoms.html
+++ b/code/mockup/uoms.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Đơn vị tính</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h2 class="mb-0">Đơn vị tính</h2>
+      <button class="btn btn-success">Tạo ĐVT</button>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-striped">
+        <thead class="table-light">
+          <tr><th>Mã</th><th>Tên</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>KG</td><td>Ki-lô-gam</td></tr>
+          <tr><td>CHIEC</td><td>Chiếc</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/code/mockup/users.html
+++ b/code/mockup/users.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Người dùng</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-secondary">
+  <div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h2 class="mb-0">Người dùng</h2>
+      <button class="btn btn-success">Tạo người dùng</button>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-striped">
+        <thead class="table-light">
+          <tr><th>Tài khoản</th><th>Họ tên</th><th>Vai trò</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>kho1</td><td>Nguyễn Văn A</td><td>Kho</td></tr>
+          <tr><td>sx1</td><td>Trần Thị B</td><td>Sản xuất</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add mockups for materials, item groups, units of measure, suppliers, users, and roles
- Link new screens in index and map them to SRS master-data requirements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689855b69f088332a4cc16af1237781d