### PR TITLE
feat: add initial PostgreSQL schema and seed data

### DIFF
--- a/MOCKUP_CODE_MAPPING.md
+++ b/MOCKUP_CODE_MAPPING.md
@@ -2,35 +2,35 @@
 
 This document links each UI mockup with the relevant business requirement section in the SRS summary (`README.md`).
 
-| Mockup file | Screen / Feature | Business requirement reference |
-|-------------|-----------------|--------------------------------|
-| login.html | Đăng nhập hệ thống | §6.1 Phân quyền – quản lý vai trò và đăng nhập【F:README.md†L194-L197】 |
-| dashboard.html | Dashboard tiến trình | §3 Yêu cầu UI/UX – Dashboard theo dõi tiến trình phiếu【F:README.md†L55-L59】 |
-| warehouses.html | Danh sách kho | §4.1 Danh mục chính – Kho【F:README.md†L61-L63】 |
-| bins.html | Quản lý bin/khu | §4.1 Danh mục chính – Khu/Bin【F:README.md†L61-L63】 |
-| items.html | Danh sách vật tư | §4.1 Danh mục chính – Vật tư (SKU)【F:README.md†L61-L63】 |
-| item_groups.html | Nhóm vật tư | §4.1 Danh mục chính – Nhóm vật tư【F:README.md†L61-L63】 |
-| uoms.html | Đơn vị tính | §4.1 Danh mục chính – ĐVT (UoM)【F:README.md†L61-L63】 |
-| suppliers.html | Nhà cung cấp | §4.1 Danh mục chính – Nhà cung cấp【F:README.md†L61-L63】 |
-| users.html | Người dùng | §4.1 Danh mục chính – Người dùng & Vai trò【F:README.md†L61-L63】 |
-| roles.html | Vai trò | §4.1 Danh mục chính – Người dùng & Vai trò【F:README.md†L61-L63】 |
-| grn_form.html | Tạo phiếu nhập (GRN) | §5.1 Quản lý kho & nhập/xuất – Nhập kho【F:README.md†L71-L75】 |
-| grn_approval.html | Duyệt phiếu nhập | §5.1 Quản lý kho & nhập/xuất – Nhập kho (duyệt)【F:README.md†L71-L75】 |
-| issue_form.html | Tạo phiếu xuất (Issue) | §5.1 Quản lý kho & nhập/xuất – Xuất kho【F:README.md†L71-L75】 |
-| issue_approval.html | Duyệt phiếu xuất | §5.1 Quản lý kho & nhập/xuất – Xuất kho (duyệt)【F:README.md†L71-L75】 |
-| transfer_form.html | Tạo phiếu điều chuyển | §5.1 Quản lý kho & nhập/xuất – Điều chuyển nội bộ【F:README.md†L71-L75】 |
-| transfer_approval.html | Duyệt điều chuyển | §5.1 Quản lý kho & nhập/xuất – Điều chuyển nội bộ (duyệt)【F:README.md†L71-L75】 |
-| stocktake_form.html | Tạo phiếu kiểm kê | §5.1 Quản lý kho & nhập/xuất – Kiểm kê & điều chỉnh【F:README.md†L71-L75】 |
-| stocktake_approval.html | Duyệt phiếu kiểm kê | §5.1 Quản lý kho & nhập/xuất – Kiểm kê & điều chỉnh (duyệt)【F:README.md†L71-L75】 |
-| return_form.html | Tạo phiếu trả hàng | §5.1 Quản lý kho & nhập/xuất – Trả hàng【F:README.md†L71-L75】 |
-| return_approval.html | Duyệt phiếu trả hàng | §5.1 Quản lý kho & nhập/xuất – Trả hàng (duyệt)【F:README.md†L71-L75】 |
-| bom_list.html | Danh sách BOM | §5.2 Quản lý BOM【F:README.md†L130-L134】 |
-| bom_detail.html | Chi tiết BOM | §5.2 Quản lý BOM【F:README.md†L130-L134】 |
-| bom_form.html | Tạo/Sửa BOM | §5.2 Quản lý BOM【F:README.md†L130-L134】 |
-| request_issue_bom.html | Lãnh theo BOM | §5.3 Lãnh vật tư theo BOM/kho chung【F:README.md†L148-L153】 |
-| request_issue_general.html | Lãnh kho chung | §5.3 Lãnh vật tư theo BOM/kho chung【F:README.md†L148-L153】 |
-| pr_form.html | Phiếu yêu cầu mua (PR) | §5.4 Thu mua【F:README.md†L169-L172】 |
-| pr_approval.html | Duyệt phiếu yêu cầu mua | §5.4 Thu mua (duyệt)【F:README.md†L169-L172】 |
-| po_form.html | Đơn mua hàng (PO) | §5.4 Thu mua【F:README.md†L169-L172】 |
-| po_approval.html | Duyệt đơn mua | §5.4 Thu mua (duyệt)【F:README.md†L169-L172】 |
-| report_inventory.html | Báo cáo tồn kho | §5.5 Báo cáo【F:README.md†L191-L192】 |
+| Mockup file | Screen / Feature | Business requirement reference | Database tables |
+|-------------|-----------------|--------------------------------|-----------------|
+| login.html | Đăng nhập hệ thống | §6.1 Phân quyền – quản lý vai trò và đăng nhập【F:README.md†L194-L197】 | users, roles |
+| dashboard.html | Dashboard tiến trình | §3 Yêu cầu UI/UX – Dashboard theo dõi tiến trình phiếu【F:README.md†L55-L59】 | grns, issues, transfers, stocktakes, returns, purchase_requests, purchase_orders |
+| warehouses.html | Danh sách kho | §4.1 Danh mục chính – Kho【F:README.md†L61-L63】 | warehouses |
+| bins.html | Quản lý bin/khu | §4.1 Danh mục chính – Khu/Bin【F:README.md†L61-L63】 | bins |
+| items.html | Danh sách vật tư | §4.1 Danh mục chính – Vật tư (SKU)【F:README.md†L61-L63】 | items |
+| item_groups.html | Nhóm vật tư | §4.1 Danh mục chính – Nhóm vật tư【F:README.md†L61-L63】 | item_groups |
+| uoms.html | Đơn vị tính | §4.1 Danh mục chính – ĐVT (UoM)【F:README.md†L61-L63】 | uoms |
+| suppliers.html | Nhà cung cấp | §4.1 Danh mục chính – Nhà cung cấp【F:README.md†L61-L63】 | suppliers |
+| users.html | Người dùng | §4.1 Danh mục chính – Người dùng & Vai trò【F:README.md†L61-L63】 | users |
+| roles.html | Vai trò | §4.1 Danh mục chính – Người dùng & Vai trò【F:README.md†L61-L63】 | roles |
+| grn_form.html | Tạo phiếu nhập (GRN) | §5.1 Quản lý kho & nhập/xuất – Nhập kho【F:README.md†L71-L75】 | grns, grn_items |
+| grn_approval.html | Duyệt phiếu nhập | §5.1 Quản lý kho & nhập/xuất – Nhập kho (duyệt)【F:README.md†L71-L75】 | grns, grn_items |
+| issue_form.html | Tạo phiếu xuất (Issue) | §5.1 Quản lý kho & nhập/xuất – Xuất kho【F:README.md†L71-L75】 | issues, issue_items |
+| issue_approval.html | Duyệt phiếu xuất | §5.1 Quản lý kho & nhập/xuất – Xuất kho (duyệt)【F:README.md†L71-L75】 | issues, issue_items |
+| transfer_form.html | Tạo phiếu điều chuyển | §5.1 Quản lý kho & nhập/xuất – Điều chuyển nội bộ【F:README.md†L71-L75】 | transfers, transfer_items |
+| transfer_approval.html | Duyệt điều chuyển | §5.1 Quản lý kho & nhập/xuất – Điều chuyển nội bộ (duyệt)【F:README.md†L71-L75】 | transfers, transfer_items |
+| stocktake_form.html | Tạo phiếu kiểm kê | §5.1 Quản lý kho & nhập/xuất – Kiểm kê & điều chỉnh【F:README.md†L71-L75】 | stocktakes, stocktake_items |
+| stocktake_approval.html | Duyệt phiếu kiểm kê | §5.1 Quản lý kho & nhập/xuất – Kiểm kê & điều chỉnh (duyệt)【F:README.md†L71-L75】 | stocktakes, stocktake_items |
+| return_form.html | Tạo phiếu trả hàng | §5.1 Quản lý kho & nhập/xuất – Trả hàng【F:README.md†L71-L75】 | returns, return_items |
+| return_approval.html | Duyệt phiếu trả hàng | §5.1 Quản lý kho & nhập/xuất – Trả hàng (duyệt)【F:README.md†L71-L75】 | returns, return_items |
+| bom_list.html | Danh sách BOM | §5.2 Quản lý BOM【F:README.md†L130-L134】 | boms, bom_items |
+| bom_detail.html | Chi tiết BOM | §5.2 Quản lý BOM【F:README.md†L130-L134】 | boms, bom_items |
+| bom_form.html | Tạo/Sửa BOM | §5.2 Quản lý BOM【F:README.md†L130-L134】 | boms, bom_items |
+| request_issue_bom.html | Lãnh theo BOM | §5.3 Lãnh vật tư theo BOM/kho chung【F:README.md†L148-L153】 | issues, issue_items, boms, bom_items |
+| request_issue_general.html | Lãnh kho chung | §5.3 Lãnh vật tư theo BOM/kho chung【F:README.md†L148-L153】 | issues, issue_items |
+| pr_form.html | Phiếu yêu cầu mua (PR) | §5.4 Thu mua【F:README.md†L169-L172】 | purchase_requests, purchase_request_items |
+| pr_approval.html | Duyệt phiếu yêu cầu mua | §5.4 Thu mua (duyệt)【F:README.md†L169-L172】 | purchase_requests, purchase_request_items |
+| po_form.html | Đơn mua hàng (PO) | §5.4 Thu mua【F:README.md†L169-L172】 | purchase_orders, purchase_order_items |
+| po_approval.html | Duyệt đơn mua | §5.4 Thu mua (duyệt)【F:README.md†L169-L172】 | purchase_orders, purchase_order_items |
+| report_inventory.html | Báo cáo tồn kho | §5.5 Báo cáo【F:README.md†L191-L192】 | inventory |

--- a/code/database/schema.sql
+++ b/code/database/schema.sql
@@ -1,0 +1,210 @@
+-- DEMAX Inventory database schema for PostgreSQL
+-- Generated based on README, SRS summary, and mockup code
+
+CREATE TABLE roles (
+    id          BIGSERIAL PRIMARY KEY,
+    name        VARCHAR(50) NOT NULL,
+    description VARCHAR(255)
+);
+
+CREATE TABLE users (
+    id            BIGSERIAL PRIMARY KEY,
+    username      VARCHAR(50) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    full_name     VARCHAR(100),
+    role_id       BIGINT REFERENCES roles(id)
+);
+
+CREATE TABLE warehouses (
+    id       BIGSERIAL PRIMARY KEY,
+    code     VARCHAR(20) NOT NULL UNIQUE,
+    name     VARCHAR(100) NOT NULL,
+    location VARCHAR(100)
+);
+
+CREATE TABLE bins (
+    id           BIGSERIAL PRIMARY KEY,
+    warehouse_id BIGINT REFERENCES warehouses(id),
+    zone         VARCHAR(20),
+    code         VARCHAR(20) NOT NULL,
+    UNIQUE (warehouse_id, zone, code)
+);
+
+CREATE TABLE item_groups (
+    id   BIGSERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE uoms (
+    id   BIGSERIAL PRIMARY KEY,
+    code VARCHAR(20) NOT NULL UNIQUE,
+    name VARCHAR(50) NOT NULL
+);
+
+CREATE TABLE items (
+    id            BIGSERIAL PRIMARY KEY,
+    sku           VARCHAR(50) NOT NULL UNIQUE,
+    name          VARCHAR(100) NOT NULL,
+    item_group_id BIGINT REFERENCES item_groups(id),
+    uom_id        BIGINT REFERENCES uoms(id),
+    min_qty       NUMERIC(12,3),
+    max_qty       NUMERIC(12,3)
+);
+
+CREATE TABLE suppliers (
+    id      BIGSERIAL PRIMARY KEY,
+    code    VARCHAR(20) NOT NULL UNIQUE,
+    name    VARCHAR(100) NOT NULL,
+    contact VARCHAR(100)
+);
+
+CREATE TABLE boms (
+    id          BIGSERIAL PRIMARY KEY,
+    code        VARCHAR(20) NOT NULL UNIQUE,
+    description VARCHAR(255)
+);
+
+CREATE TABLE bom_items (
+    id     BIGSERIAL PRIMARY KEY,
+    bom_id BIGINT REFERENCES boms(id),
+    item_id BIGINT REFERENCES items(id),
+    quantity NUMERIC(12,3) NOT NULL,
+    uom_id  BIGINT REFERENCES uoms(id)
+);
+
+CREATE TABLE inventory (
+    id           BIGSERIAL PRIMARY KEY,
+    item_id      BIGINT REFERENCES items(id),
+    warehouse_id BIGINT REFERENCES warehouses(id),
+    bin_id       BIGINT REFERENCES bins(id),
+    quantity     NUMERIC(12,3) NOT NULL DEFAULT 0
+);
+
+CREATE TABLE grns (
+    id           BIGSERIAL PRIMARY KEY,
+    code         VARCHAR(30) NOT NULL UNIQUE,
+    warehouse_id BIGINT REFERENCES warehouses(id),
+    supplier_id  BIGINT REFERENCES suppliers(id),
+    received_by  BIGINT REFERENCES users(id),
+    approved_by  BIGINT REFERENCES users(id),
+    status       VARCHAR(20) NOT NULL DEFAULT 'pending',
+    received_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE grn_items (
+    id      BIGSERIAL PRIMARY KEY,
+    grn_id  BIGINT REFERENCES grns(id),
+    item_id BIGINT REFERENCES items(id),
+    quantity NUMERIC(12,3) NOT NULL,
+    uom_id  BIGINT REFERENCES uoms(id),
+    unit_price NUMERIC(12,2)
+);
+
+CREATE TABLE issues (
+    id           BIGSERIAL PRIMARY KEY,
+    code         VARCHAR(30) NOT NULL UNIQUE,
+    warehouse_id BIGINT REFERENCES warehouses(id),
+    requested_by BIGINT REFERENCES users(id),
+    approved_by  BIGINT REFERENCES users(id),
+    status       VARCHAR(20) NOT NULL DEFAULT 'pending',
+    issued_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE issue_items (
+    id       BIGSERIAL PRIMARY KEY,
+    issue_id BIGINT REFERENCES issues(id),
+    item_id  BIGINT REFERENCES items(id),
+    quantity NUMERIC(12,3) NOT NULL,
+    uom_id   BIGINT REFERENCES uoms(id)
+);
+
+CREATE TABLE transfers (
+    id                BIGSERIAL PRIMARY KEY,
+    code              VARCHAR(30) NOT NULL UNIQUE,
+    from_warehouse_id BIGINT REFERENCES warehouses(id),
+    to_warehouse_id   BIGINT REFERENCES warehouses(id),
+    requested_by      BIGINT REFERENCES users(id),
+    approved_by       BIGINT REFERENCES users(id),
+    status            VARCHAR(20) NOT NULL DEFAULT 'pending',
+    transferred_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE transfer_items (
+    id          BIGSERIAL PRIMARY KEY,
+    transfer_id BIGINT REFERENCES transfers(id),
+    item_id     BIGINT REFERENCES items(id),
+    quantity    NUMERIC(12,3) NOT NULL,
+    uom_id      BIGINT REFERENCES uoms(id)
+);
+
+CREATE TABLE stocktakes (
+    id          BIGSERIAL PRIMARY KEY,
+    code        VARCHAR(30) NOT NULL UNIQUE,
+    warehouse_id BIGINT REFERENCES warehouses(id),
+    counted_by  BIGINT REFERENCES users(id),
+    approved_by BIGINT REFERENCES users(id),
+    status      VARCHAR(20) NOT NULL DEFAULT 'pending',
+    counted_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE stocktake_items (
+    id           BIGSERIAL PRIMARY KEY,
+    stocktake_id BIGINT REFERENCES stocktakes(id),
+    item_id      BIGINT REFERENCES items(id),
+    system_qty   NUMERIC(12,3) NOT NULL,
+    counted_qty  NUMERIC(12,3) NOT NULL
+);
+
+CREATE TABLE returns (
+    id           BIGSERIAL PRIMARY KEY,
+    code         VARCHAR(30) NOT NULL UNIQUE,
+    warehouse_id BIGINT REFERENCES warehouses(id),
+    returned_by  BIGINT REFERENCES users(id),
+    approved_by  BIGINT REFERENCES users(id),
+    status       VARCHAR(20) NOT NULL DEFAULT 'pending',
+    returned_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE return_items (
+    id        BIGSERIAL PRIMARY KEY,
+    return_id BIGINT REFERENCES returns(id),
+    item_id   BIGINT REFERENCES items(id),
+    quantity  NUMERIC(12,3) NOT NULL,
+    uom_id    BIGINT REFERENCES uoms(id)
+);
+
+CREATE TABLE purchase_requests (
+    id          BIGSERIAL PRIMARY KEY,
+    code        VARCHAR(30) NOT NULL UNIQUE,
+    requested_by BIGINT REFERENCES users(id),
+    approved_by  BIGINT REFERENCES users(id),
+    status      VARCHAR(20) NOT NULL DEFAULT 'pending',
+    requested_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE purchase_request_items (
+    id                  BIGSERIAL PRIMARY KEY,
+    purchase_request_id BIGINT REFERENCES purchase_requests(id),
+    item_id             BIGINT REFERENCES items(id),
+    quantity            NUMERIC(12,3) NOT NULL,
+    uom_id              BIGINT REFERENCES uoms(id)
+);
+
+CREATE TABLE purchase_orders (
+    id           BIGSERIAL PRIMARY KEY,
+    code         VARCHAR(30) NOT NULL UNIQUE,
+    supplier_id  BIGINT REFERENCES suppliers(id),
+    requested_by BIGINT REFERENCES users(id),
+    approved_by  BIGINT REFERENCES users(id),
+    status       VARCHAR(20) NOT NULL DEFAULT 'pending',
+    ordered_at   TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE purchase_order_items (
+    id                 BIGSERIAL PRIMARY KEY,
+    purchase_order_id  BIGINT REFERENCES purchase_orders(id),
+    item_id            BIGINT REFERENCES items(id),
+    quantity           NUMERIC(12,3) NOT NULL,
+    uom_id             BIGINT REFERENCES uoms(id),
+    unit_price         NUMERIC(12,2)
+);

--- a/code/database/seeder.sql
+++ b/code/database/seeder.sql
@@ -1,0 +1,102 @@
+-- Mock data for DEMAX Inventory
+
+INSERT INTO roles (name, description) VALUES
+  ('Kho', 'Quản lý kho'),
+  ('Sản xuất', 'Nhân viên sản xuất'),
+  ('Thu mua', 'Nhân viên thu mua'),
+  ('Duyệt', 'Người duyệt'),
+  ('Admin', 'Quản trị');
+
+INSERT INTO users (username, password_hash, full_name, role_id) VALUES
+  ('kho1', 'pass', 'Nguyễn Văn A', 1),
+  ('sx1', 'pass', 'Trần Thị B', 2),
+  ('tm1', 'pass', 'Phạm Văn C', 3),
+  ('duyet1', 'pass', 'Lê Thị D', 4),
+  ('admin', 'pass', 'Quản trị', 5);
+
+INSERT INTO warehouses (code, name, location) VALUES
+  ('WH1', 'Kho chính', 'Khu A'),
+  ('WH2', 'Kho thành phẩm', 'Khu B');
+
+INSERT INTO bins (warehouse_id, zone, code) VALUES
+  (1, 'A', 'A1'),
+  (1, 'A', 'A2'),
+  (2, 'B', 'B1');
+
+INSERT INTO item_groups (name) VALUES
+  ('Nguyên liệu'),
+  ('Hoá chất');
+
+INSERT INTO uoms (code, name) VALUES
+  ('TAM', 'Tấm'),
+  ('LON', 'Lon'),
+  ('KG', 'Ki-lô-gam'),
+  ('CHIEC', 'Chiếc');
+
+INSERT INTO items (sku, name, item_group_id, uom_id, min_qty, max_qty) VALUES
+  ('VT001', 'Thép tấm', 1, 1, 10, 100),
+  ('VT002', 'Sơn đỏ', 2, 2, 5, 50),
+  ('VT003', 'Bulong M8', 1, 4, 50, 500),
+  ('VT004', 'Đai ốc M8', 1, 4, 50, 500);
+
+INSERT INTO suppliers (code, name, contact) VALUES
+  ('NCC01', 'Công ty A', '0123456789'),
+  ('NCC02', 'Công ty B', '0987654321');
+
+INSERT INTO boms (code, description) VALUES
+  ('BOM001', 'BOM demo');
+
+INSERT INTO bom_items (bom_id, item_id, quantity, uom_id) VALUES
+  (1, 3, 4, 4),
+  (1, 1, 1, 1);
+
+INSERT INTO inventory (item_id, warehouse_id, bin_id, quantity) VALUES
+  (1, 1, 1, 100),
+  (2, 1, 1, 50),
+  (3, 1, 1, 200),
+  (4, 1, 1, 200);
+
+INSERT INTO grns (code, warehouse_id, supplier_id, received_by, approved_by, status, received_at) VALUES
+  ('GRN-20250501-001', 1, 1, 1, 4, 'approved', '2025-05-01');
+
+INSERT INTO grn_items (grn_id, item_id, quantity, uom_id, unit_price) VALUES
+  (1, 3, 100, 4, 1000),
+  (1, 4, 100, 4, 800);
+
+INSERT INTO issues (code, warehouse_id, requested_by, approved_by, status, issued_at) VALUES
+  ('ISS-20250502-001', 1, 2, 4, 'approved', '2025-05-02');
+
+INSERT INTO issue_items (issue_id, item_id, quantity, uom_id) VALUES
+  (1, 3, 40, 4),
+  (1, 4, 40, 4);
+
+INSERT INTO transfers (code, from_warehouse_id, to_warehouse_id, requested_by, approved_by, status, transferred_at) VALUES
+  ('TRF-20250503-001', 1, 2, 1, 4, 'approved', '2025-05-03');
+
+INSERT INTO transfer_items (transfer_id, item_id, quantity, uom_id) VALUES
+  (1, 1, 20, 1);
+
+INSERT INTO stocktakes (code, warehouse_id, counted_by, approved_by, status, counted_at) VALUES
+  ('STK-20250504-001', 1, 1, 4, 'approved', '2025-05-04');
+
+INSERT INTO stocktake_items (stocktake_id, item_id, system_qty, counted_qty) VALUES
+  (1, 3, 200, 195),
+  (1, 4, 200, 200);
+
+INSERT INTO returns (code, warehouse_id, returned_by, approved_by, status, returned_at) VALUES
+  ('RTN-20250505-001', 1, 2, 4, 'approved', '2025-05-05');
+
+INSERT INTO return_items (return_id, item_id, quantity, uom_id) VALUES
+  (1, 3, 10, 4);
+
+INSERT INTO purchase_requests (code, requested_by, approved_by, status, requested_at) VALUES
+  ('PR-20250506-001', 1, 4, 'approved', '2025-05-06');
+
+INSERT INTO purchase_request_items (purchase_request_id, item_id, quantity, uom_id) VALUES
+  (1, 1, 50, 1);
+
+INSERT INTO purchase_orders (code, supplier_id, requested_by, approved_by, status, ordered_at) VALUES
+  ('PO-20250507-001', 1, 3, 5, 'approved', '2025-05-07');
+
+INSERT INTO purchase_order_items (purchase_order_id, item_id, quantity, uom_id, unit_price) VALUES
+  (1, 1, 50, 1, 2000);


### PR DESCRIPTION
## Summary
- add PostgreSQL schema for DEMAX inventory including master and transaction tables
- provide seeder with mock data for roles, users, warehouses, items and sample transactions
- document mapping of mockup screens to corresponding database tables

## Testing
- `psql -f code/database/schema.sql` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68986935f3188332baa7366a760c04a1